### PR TITLE
SO1S-493 inference 인퍼런스 서버 배포시 모델이 2 번 로드 되는 현상

### DIFF
--- a/build-v2-cpu/apps/main.py
+++ b/build-v2-cpu/apps/main.py
@@ -17,4 +17,4 @@ def predict(input):
     global artifacts
     if artifacts is None:
         artifacts = prepared.load_artifacts()
-    return prepared.run(artifacts=artifacts, input=input)
+    return prepared.run(artifacts, input)

--- a/build-v2-cpu/apps/main.py
+++ b/build-v2-cpu/apps/main.py
@@ -1,5 +1,6 @@
 import os
 import bentoml
+from bentoml.io import Text, IODescriptor
 import prepared
 import utils
 
@@ -16,5 +17,12 @@ svc = bentoml.Service(model_name)
 def predict(input):
     global artifacts
     if artifacts is None:
-        artifacts = prepared.load_artifacts()
+        load("load")
     return prepared.run(artifacts, input)
+
+@svc.api(input=Text(), output=Text())
+def load(input):
+    global artifacts
+    if artifacts is None:
+        artifacts = prepared.load_artifacts()
+    return "load success"

--- a/build-v2-cpu/apps/main.py
+++ b/build-v2-cpu/apps/main.py
@@ -8,9 +8,13 @@ output_type = utils.get_data_type(os.environ['OUTPUT_TYPE'])
 model_name = os.environ['MODEL_NAME']
 library = os.environ['LIBRARY']
 
-artifacts = prepared.load_artifacts()
+global artifacts
+artifacts = None
 svc = bentoml.Service(model_name)
 
 @svc.api(input=input_type, output=output_type)
 def predict(input):
-    return prepared.run(artifacts, input)
+    global artifacts
+    if artifacts is None:
+        artifacts = prepared.load_artifacts()
+    return prepared.run(artifacts=artifacts, input=input)

--- a/build-v2-gpu/apps/main.py
+++ b/build-v2-gpu/apps/main.py
@@ -17,4 +17,4 @@ def predict(input):
     global artifacts
     if artifacts is None:
         artifacts = prepared.load_artifacts()
-    return prepared.run(artifacts=artifacts, input=input)
+    return prepared.run(artifacts, input)

--- a/build-v2-gpu/apps/main.py
+++ b/build-v2-gpu/apps/main.py
@@ -1,5 +1,6 @@
 import os
 import bentoml
+from bentoml.io import Text, IODescriptor
 import prepared
 import utils
 
@@ -16,5 +17,12 @@ svc = bentoml.Service(model_name)
 def predict(input):
     global artifacts
     if artifacts is None:
-        artifacts = prepared.load_artifacts()
+        load("load")
     return prepared.run(artifacts, input)
+
+@svc.api(input=Text(), output=Text())
+def load(input):
+    global artifacts
+    if artifacts is None:
+        artifacts = prepared.load_artifacts()
+    return "load success"

--- a/build-v2-gpu/apps/main.py
+++ b/build-v2-gpu/apps/main.py
@@ -8,9 +8,13 @@ output_type = utils.get_data_type(os.environ['OUTPUT_TYPE'])
 model_name = os.environ['MODEL_NAME']
 library = os.environ['LIBRARY']
 
-artifacts = prepared.load_artifacts()
+global artifacts
+artifacts = None
 svc = bentoml.Service(model_name)
 
 @svc.api(input=input_type, output=output_type)
 def predict(input):
-    return prepared.run(artifacts, input)
+    global artifacts
+    if artifacts is None:
+        artifacts = prepared.load_artifacts()
+    return prepared.run(artifacts=artifacts, input=input)


### PR DESCRIPTION
# SO1S-493 inference 인퍼런스 서버 배포시 모델이 2 번 로드 되는 현상


## Tasks

- [x]  모델을 load 하는 api 생성
- [x]  main.py에서 model load의 검증 체크 진행하도록 변경


## Discussion

- bentoml 실행시 container의 enrtrypoint에서는 한번 실행되는 것이 맞으나 bentoml serve 과정 중 main.py 자체가 여러번 실행되는 것을 확인했습니다. 그래서 이를 load 별도의 api로 빼서 최초 deployment시 한번 실행해서 부트업 해주도록하고 이후에는 로드가 되지 않도록 변경했습니다.


## Jira

- SO1S-493